### PR TITLE
Update << and >> (arithmetic-shift )in plasm.rkt

### DIFF
--- a/plasm.rkt
+++ b/plasm.rkt
@@ -103,8 +103,8 @@
                      [(list (? %label-promise? a) (? %label-promise? b))
                       (%label-promise (append (%label-promise-depends a) (%label-promise-depends b))
                                       (lambda () (op ((%label-promise-calculate a)) ((%label-promise-calculate b)))))]))]
-           [%<< (mkop (lambda (a b) (arithmetic-shift a (-a b))))]
-           [%>> (mkop arithmetic-shift)]
+           [%<< (mkop arithmetic-shift)]
+           [%>> (mkop (lambda (a b) (arithmetic-shift a (- b))))]
            [mod (mkop modulo)]
            [mkrot (lambda (size mask op)
                     (lambda (a b)


### PR DESCRIPTION
In the [racket documentation](https://docs.racket-lang.org/reference/generic-numbers.html#%28def._%28%28quote._~23~25kernel%29._arithmetic-shift%29%29), arithmetic-shift is defined as a bitwise shift left (<<) and to do a right shift (>>) the second argument has to be made negative. I am not sure what the result of 
```
(aritmetic-shift a (-a b))
```
is and I am guessing it has to do with the label-promise (which I still don't fully understand), but these changes return the second (correct?) result in issue  #8 .