### PR TITLE
Pdu4 atmega##u# 2

### DIFF
--- a/avr8.rkt
+++ b/avr8.rkt
@@ -93,9 +93,13 @@
 
 (define (avr-imm-6b? i) (between? 0 i 63))
 (define (avr-imm-6b i) (+ (& #x0f i) (<< (& #x30 i) 2)))
+(define (avr-imm-6q i) (+ (<< (bit-field i 5 6) 13)  (<< (bit-field i 3 5) 10 ) (bit-field i 0 3) )
 
 (define (avr-imm-b? i) (between? -128 i 127))
 (define (avr-imm-b i) (+ (& #x0f i) (<< (& #xf0 i) 4)))
+
+(define (avr-imm-16b? i) (between? 0 i 65535))
+(define (aavr-imm-16b i) i)
 
 (define (avr-bit? i) (between? 0 i 7))
 (define (avr-bit-d i) (<< i 4))
@@ -252,6 +256,39 @@
    [`(spm ,(? avr-reg? reg) z+) (dw (+ #x92f8 (avr-reg-d reg)))]
    
    [`(ldi ,(? avr-reg-hi? src) ,(? avr-imm-b? b))          (dw (+ #xe000 (avr-reg-hi-d src) (avr-imm-b b)))]
+   
+   [`(ld ,(? avr-reg? reg) x)  (dw (+ #x900c (avr-reg-d reg)))]
+   [`(ld ,(? avr-reg? reg) x+) (dw (+ #x900d (avr-reg-d reg)))]
+   [`(ld ,(? avr-reg? reg) x-)  (dw (+ #x900e (avr-reg-d reg)))]
+  
+   [`(st ,(? avr-reg? reg) x)  (dw (+ #x920c (avr-reg-d reg)))]
+   [`(st ,(? avr-reg? reg) x+) (dw (+ #x920d (avr-reg-d reg)))]
+   [`(st ,(? avr-reg? reg) x-) (dw (+ #x920e (avr-reg-d reg)))]
+  
+   
+   [`(ld ,(? avr-reg? reg) y)  (dw (+ #x8008 (avr-reg-d reg)))]
+   [`(ld ,(? avr-reg? reg) y+) (dw (+ #x9009 (avr-reg-d reg)))]
+   [`(ld ,(? avr-reg? reg) y-) (dw (+ #x900a (avr-reg-d reg)))]
+   [`(ldd ,(? avr-reg? reg) y+ (? avr-imm-6b? q)) (dw (+ #x8008 (avr-imm-6q q)))]
+
+   [`(st ,(? avr-reg? reg) y)  (dw (+ #x8208 (avr-reg-d reg)))]
+   [`(st ,(? avr-reg? reg) y+) (dw (+ #x9209 (avr-reg-d reg)))]
+   [`(st ,(? avr-reg? reg) y-) (dw (+ #x920a (avr-reg-d reg)))]
+   [`(std ,(? avr-reg? reg) y+ (? avr-imm-6b? q)) (dw (+ #x8208 (avr-imm-6q q)))]
+   
+   [`(ld ,(? avr-reg? reg) z)  (dw (+ #x8000 (avr-reg-d reg)))]
+   [`(ld ,(? avr-reg? reg) z+) (dw (+ #x9001 (avr-reg-d reg)))]
+   [`(ld ,(? avr-reg? reg) z-) (dw (+ #x9002 (avr-reg-d reg)))]
+   [`(ldd ,(? avr-reg? reg) z+ (? avr-imm-6b? q))  (dw (+ #x8000 (avr-imm-6q q)))]
+
+   [`(st ,(? avr-reg? reg) z)  (dw (+ #x8200 (avr-reg-d reg)))]
+   [`(st ,(? avr-reg? reg) z+) (dw (+ #x9201 (avr-reg-d reg)))]
+   [`(st ,(? avr-reg? reg) z-) (dw (+ #x9202 (avr-reg-d reg)))]
+   [`(std ,(? avr-reg? reg) z+ (? avr-imm-6b? q)) (dw (+ #x8200 (avr-imm-6q q)))]
+
+
+   [`(lds ,(? avr-reg? reg) (? avr-imm-16b? addr))  (dw (+ #x9000 (avr-reg-d reg)) (avr-imm-16b addr))]
+   [`(sts ,(? avr-reg? reg) (? avr-imm-16b? addr)) (dw (+ #x9200 (avr-reg-d reg)) (avr-imm-16b addr))]
    
    ; extended load program memory
    [`(elpm)                      (dw #x95d8)]

--- a/avr8.rkt
+++ b/avr8.rkt
@@ -249,6 +249,7 @@
    [`(lpm ,(? avr-reg? reg) z)  (dw (+ #x9004 (avr-reg-d reg)))]
    [`(lpm ,(? avr-reg? reg) z+) (dw (+ #x9005 (avr-reg-d reg)))]
    [`(spm)                      (dw #x95e8)]
+   [`(spm ,(? avr-reg? reg) z+) (dw (+ #x92f8 (avr-reg-d reg)))]
    
    [`(ldi ,(? avr-reg-hi? src) ,(? avr-imm-b? b))          (dw (+ #xe000 (avr-reg-hi-d src) (avr-imm-b b)))]
    

--- a/avr8.rkt
+++ b/avr8.rkt
@@ -208,7 +208,9 @@
    [`(bst  ,(? avr-reg? src) ,(? avr-bit? bit))  (dw (+ #xfa00 bit (avr-reg-d src)))]
    [`(sbrc ,(? avr-reg? reg) ,(? avr-bit? bit))  (dw (+ #xfc00 bit (avr-reg-d reg)))]
    [`(sbrs ,(? avr-reg? reg) ,(? avr-bit? bit))  (dw (+ #xfe00 bit (avr-reg-d reg)))]
+   
    [`(sbr ,(? avr-reg-hi? src) ,(? avr-imm-b? b))          (dw (+ #x6000 (avr-reg-hi-d src) (avr-imm-b b)))]
+   
    [`(ser ,(? avr-reg-hi? src))         (dw (+ #xef0f (avr-reg-hi-d src)))]
    
    [`(brbc ,(? avr-bit? s) ,(? avr-rel-7b? dst)) (dw (+ #xf400 s (avr-rel-7b dst)))]
@@ -253,7 +255,7 @@
    [`(spm)                      (dw #x95e8)]
    [`(spm ,(? avr-reg? reg) z+) (dw (+ #x92f8 (avr-reg-d reg)))]
    
-   [`(ldi ,(? avr-reg-hi? src) ,(? avr-imm-b? b))          (dw (+ #xe000 (avr-reg-hi-d src) (avr-imm-b b)))]
+   [`(ldi ,(? avr-reg-hi? src) ,(? avr-imm-b? b)) (dw (+ #xe000 (avr-reg-hi-d src) (avr-imm-b b)))]
    
    [`(ld ,(? avr-reg? reg) x)  (dw (+ #x900c (avr-reg-d reg)))]
    [`(ld ,(? avr-reg? reg) x+) (dw (+ #x900d (avr-reg-d reg)))]
@@ -267,22 +269,22 @@
    [`(ld ,(? avr-reg? reg) y)  (dw (+ #x8008 (avr-reg-d reg)))]
    [`(ld ,(? avr-reg? reg) y+) (dw (+ #x9009 (avr-reg-d reg)))]
    [`(ld ,(? avr-reg? reg) y-) (dw (+ #x900a (avr-reg-d reg)))]
-   [`(ldd ,(? avr-reg? reg) y+ ,(? avr-imm-6b? q)) (dw (+ #x8008 (avr-imm-6q q)))]
+   [`(ldd ,(? avr-reg? reg) y+ ,(? avr-imm-6b? q)) (dw (+ #x8008 (avr-reg-d reg) (avr-imm-6q q)))]
 
    [`(st ,(? avr-reg? reg) y)  (dw (+ #x8208 (avr-reg-d reg)))]
    [`(st ,(? avr-reg? reg) y+) (dw (+ #x9209 (avr-reg-d reg)))]
    [`(st ,(? avr-reg? reg) y-) (dw (+ #x920a (avr-reg-d reg)))]
-   [`(std ,(? avr-reg? reg) y+ ,(? avr-imm-6b? q)) (dw (+ #x8208 (avr-imm-6q q)))]
+   [`(std ,(? avr-reg? reg) y+ ,(? avr-imm-6b? q)) (dw (+ #x8208 (avr-reg-d reg) (avr-imm-6q q)))]
    
    [`(ld ,(? avr-reg? reg) z)  (dw (+ #x8000 (avr-reg-d reg)))]
    [`(ld ,(? avr-reg? reg) z+) (dw (+ #x9001 (avr-reg-d reg)))]
    [`(ld ,(? avr-reg? reg) z-) (dw (+ #x9002 (avr-reg-d reg)))]
-   [`(ldd ,(? avr-reg? reg) z+ ,(? avr-imm-6b? q))  (dw (+ #x8000 (avr-imm-6q q)))]
+   [`(ldd ,(? avr-reg? reg) z+ ,(? avr-imm-6b? q))  (dw (+ #x8000 (avr-reg-d reg) (avr-imm-6q q)))]
 
    [`(st ,(? avr-reg? reg) z)  (dw (+ #x8200 (avr-reg-d reg)))]
    [`(st ,(? avr-reg? reg) z+) (dw (+ #x9201 (avr-reg-d reg)))]
    [`(st ,(? avr-reg? reg) z-) (dw (+ #x9202 (avr-reg-d reg)))]
-   [`(std ,(? avr-reg? reg) z+ ,(? avr-imm-6b? q)) (dw (+ #x8200 (avr-imm-6q q)))]
+   [`(std ,(? avr-reg? reg) z+ ,(? avr-imm-6b? q)) (dw (+ #x8200 (avr-reg-d reg) (avr-imm-6q q)))]
 
 
    [`(lds ,(? avr-reg? reg) ,(? avr-imm-16b? addr))  (dw (+ #x9000 (avr-reg-d reg)) (avr-imm-16b addr))]

--- a/avr8.rkt
+++ b/avr8.rkt
@@ -238,8 +238,6 @@
    [`(swap ,(? avr-reg? reg)) (dw (+ #x9402 (avr-reg-d reg)))]
    [`(inc ,(? avr-reg? reg))  (dw (+ #x9403 (avr-reg-d reg)))]
    [`(dec ,(? avr-reg? reg))  (dw (+ #x940a (avr-reg-d reg)))]
-   
-   
 
    [`(muls ,(? avr-reg-hi? d) ,(? avr-reg-hi? r))       (dw (+ #x0200 (avr-reg-hi-d d) (avr-reg-hi-r r)))]
 

--- a/avr8.rkt
+++ b/avr8.rkt
@@ -93,13 +93,13 @@
 
 (define (avr-imm-6b? i) (between? 0 i 63))
 (define (avr-imm-6b i) (+ (& #x0f i) (<< (& #x30 i) 2)))
-(define (avr-imm-6q i) (+ (<< (bit-field i 5 6) 13)  (<< (bit-field i 3 5) 10 ) (bit-field i 0 3) )
+(define (avr-imm-6q i) (+ (<< (bit-field i 5 6) 13)  (<< (bit-field i 3 5) 10 ) (bit-field i 0 3) ))
 
 (define (avr-imm-b? i) (between? -128 i 127))
 (define (avr-imm-b i) (+ (& #x0f i) (<< (& #xf0 i) 4)))
 
 (define (avr-imm-16b? i) (between? 0 i 65535))
-(define (aavr-imm-16b i) i)
+(define (avr-imm-16b i) i)
 
 (define (avr-bit? i) (between? 0 i 7))
 (define (avr-bit-d i) (<< i 4))
@@ -267,26 +267,26 @@
    [`(ld ,(? avr-reg? reg) y)  (dw (+ #x8008 (avr-reg-d reg)))]
    [`(ld ,(? avr-reg? reg) y+) (dw (+ #x9009 (avr-reg-d reg)))]
    [`(ld ,(? avr-reg? reg) y-) (dw (+ #x900a (avr-reg-d reg)))]
-   [`(ldd ,(? avr-reg? reg) y+ (? avr-imm-6b? q)) (dw (+ #x8008 (avr-imm-6q q)))]
+   [`(ldd ,(? avr-reg? reg) y+ ,(? avr-imm-6b? q)) (dw (+ #x8008 (avr-imm-6q q)))]
 
    [`(st ,(? avr-reg? reg) y)  (dw (+ #x8208 (avr-reg-d reg)))]
    [`(st ,(? avr-reg? reg) y+) (dw (+ #x9209 (avr-reg-d reg)))]
    [`(st ,(? avr-reg? reg) y-) (dw (+ #x920a (avr-reg-d reg)))]
-   [`(std ,(? avr-reg? reg) y+ (? avr-imm-6b? q)) (dw (+ #x8208 (avr-imm-6q q)))]
+   [`(std ,(? avr-reg? reg) y+ ,(? avr-imm-6b? q)) (dw (+ #x8208 (avr-imm-6q q)))]
    
    [`(ld ,(? avr-reg? reg) z)  (dw (+ #x8000 (avr-reg-d reg)))]
    [`(ld ,(? avr-reg? reg) z+) (dw (+ #x9001 (avr-reg-d reg)))]
    [`(ld ,(? avr-reg? reg) z-) (dw (+ #x9002 (avr-reg-d reg)))]
-   [`(ldd ,(? avr-reg? reg) z+ (? avr-imm-6b? q))  (dw (+ #x8000 (avr-imm-6q q)))]
+   [`(ldd ,(? avr-reg? reg) z+ ,(? avr-imm-6b? q))  (dw (+ #x8000 (avr-imm-6q q)))]
 
    [`(st ,(? avr-reg? reg) z)  (dw (+ #x8200 (avr-reg-d reg)))]
    [`(st ,(? avr-reg? reg) z+) (dw (+ #x9201 (avr-reg-d reg)))]
    [`(st ,(? avr-reg? reg) z-) (dw (+ #x9202 (avr-reg-d reg)))]
-   [`(std ,(? avr-reg? reg) z+ (? avr-imm-6b? q)) (dw (+ #x8200 (avr-imm-6q q)))]
+   [`(std ,(? avr-reg? reg) z+ ,(? avr-imm-6b? q)) (dw (+ #x8200 (avr-imm-6q q)))]
 
 
-   [`(lds ,(? avr-reg? reg) (? avr-imm-16b? addr))  (dw (+ #x9000 (avr-reg-d reg)) (avr-imm-16b addr))]
-   [`(sts ,(? avr-reg? reg) (? avr-imm-16b? addr)) (dw (+ #x9200 (avr-reg-d reg)) (avr-imm-16b addr))]
+   [`(lds ,(? avr-reg? reg) ,(? avr-imm-16b? addr))  (dw (+ #x9000 (avr-reg-d reg)) (avr-imm-16b addr))]
+   [`(sts ,(? avr-reg? reg) ,(? avr-imm-16b? addr)) (dw (+ #x9200 (avr-reg-d reg)) (avr-imm-16b addr))]
    
    ; extended load program memory
    [`(elpm)                      (dw #x95d8)]


### PR DESCRIPTION
Added load and store instructions and some functions to support new instructions

NOTE: I had to change the syntax of the last ld and st instruction from `ldd imm z+q` to `(ldd imm z+ q) though another solution would be to create a new instruction syntax, eg `(lzi imm q)` or (ldd imm q)

Also I think at this point it would be useful to separate out the different chips like was done for the 6502 code, it should not be that hard for most except for the ATtiny branch.